### PR TITLE
Add Recitativos context and integrate with main screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { StatusBar } from "react-native";
 import { useFonts } from "expo-font";
 import { ThemeProvider } from "@contexts/tema";
+import { RecitativosProvider } from "@contexts/RecitativosContext";
 import styled from "styled-components/native";
 import AppNavigator from "./AppNavigator";
 
@@ -19,10 +20,12 @@ export default function App() {
 
   return (
     <ThemeProvider>
-      <StatusBar barStyle="default" />
-      <Container>
-        <AppNavigator />
-      </Container>
+      <RecitativosProvider>
+        <StatusBar barStyle="default" />
+        <Container>
+          <AppNavigator />
+        </Container>
+      </RecitativosProvider>
     </ThemeProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "recitativos",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/native": "^7.1.9",
         "@react-navigation/stack": "^7.3.2",
         "expo": "^53.0.9",
@@ -2482,6 +2483,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -5709,6 +5722,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -6455,6 +6477,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/native": "^7.1.9",
     "@react-navigation/stack": "^7.3.2",
     "expo": "^53.0.9",

--- a/src/components/ListItem/ListItemRoot.tsx
+++ b/src/components/ListItem/ListItemRoot.tsx
@@ -11,6 +11,8 @@ import {ReactNode} from "react";
 type ContainerProps = {
 	children: ReactNode;
 	selected: boolean;
+	onPress?: () => void;
+	onLongPress?: () => void;
 };
 
 /**
@@ -18,9 +20,9 @@ type ContainerProps = {
  * @param {ContainerProps} props - Propriedades do componente.
  * @returns {JSX.Element} Elemento React do item da lista.
  */
-export default function ListItemRoot({children, selected}: ContainerProps) {
+export default function ListItemRoot({children, selected, onPress, onLongPress}: ContainerProps) {
 	return (
-		<TouchableOpacity>
+		<TouchableOpacity onPress={onPress} onLongPress={onLongPress}>
 			<Container selected={selected}>
 				{children}
 			</Container>

--- a/src/components/ListItem/index.tsx
+++ b/src/components/ListItem/index.tsx
@@ -19,6 +19,8 @@ export type ListItemProps = ListItemAvatarProps & {
   hasRightIcon?: boolean;
   selected?: boolean;
   danger?: boolean;
+  onPress?: () => void;
+  onLongPress?: () => void;
 };
 
 /**
@@ -43,11 +45,17 @@ export default function ListItemComponent({
   hasRightIcon,
   selected = false,
   danger = false,
+  onPress,
+  onLongPress,
 }: ListItemProps) {
   switch (type) {
     case "Icon":
       return (
-        <ListItemRoot selected={selected}>
+        <ListItemRoot
+          selected={selected}
+          onPress={onPress}
+          onLongPress={onLongPress}
+        >
           <ListItemIcon icon={leftIcon} side="left" danger={danger} />
           <ListItemContent {...{ title, description, danger }} />
           {hasRightIcon && <ListItemIcon side="right" selected={selected} />}
@@ -55,7 +63,11 @@ export default function ListItemComponent({
       );
     case "Avatar":
       return (
-        <ListItemRoot selected={selected}>
+        <ListItemRoot
+          selected={selected}
+          onPress={onPress}
+          onLongPress={onLongPress}
+        >
           <ListItemAvatar avatar={avatar} />
           <ListItemContent {...{ title, description, danger }} />
           {hasRightIcon && <ListItemIcon selected={selected} side="right" />}
@@ -64,7 +76,11 @@ export default function ListItemComponent({
 
     default:
       return (
-        <ListItemRoot selected={selected}>
+        <ListItemRoot
+          selected={selected}
+          onPress={onPress}
+          onLongPress={onLongPress}
+        >
           <ListItemContent {...{ title, description, danger }} />
           {hasRightIcon && <ListItemIcon side="right" selected={selected} />}
         </ListItemRoot>

--- a/src/contexts/RecitativosContext.tsx
+++ b/src/contexts/RecitativosContext.tsx
@@ -1,0 +1,86 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const RECITATIVOS_STORAGE_KEY = '@recitativos';
+
+export interface Recitativo {
+  title: string;
+  verses: string[];
+}
+
+interface RecitativosContextType {
+  recitativos: Recitativo[];
+  addRecitativo: (recitativo: Recitativo) => void;
+  moveRecitativoUp: (index: number) => void;
+  moveRecitativoDown: (index: number) => void;
+  deleteRecitativo: (index: number) => void;
+}
+
+const RecitativosContext = createContext<RecitativosContextType | undefined>(undefined);
+
+export const RecitativosProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [recitativos, setRecitativos] = useState<Recitativo[]>([]);
+
+  useEffect(() => {
+    const loadRecitativos = async () => {
+      try {
+        const storedRecitativos = await AsyncStorage.getItem(RECITATIVOS_STORAGE_KEY);
+        if (storedRecitativos) {
+          setRecitativos(JSON.parse(storedRecitativos));
+        }
+      } catch (e) {
+        console.error("Failed to load recitativos.", e);
+      }
+    };
+
+    loadRecitativos();
+  }, []);
+
+  const saveRecitativos = async (newRecitativos: Recitativo[]) => {
+    try {
+      await AsyncStorage.setItem(RECITATIVOS_STORAGE_KEY, JSON.stringify(newRecitativos));
+      setRecitativos(newRecitativos);
+    } catch (e) {
+      console.error("Failed to save recitativos.", e);
+    }
+  };
+
+  const addRecitativo = (recitativo: Recitativo) => {
+    saveRecitativos([...recitativos, recitativo]);
+  };
+
+  const moveRecitativoUp = (index: number) => {
+    if (index === 0) return;
+    const newRecitativos = [...recitativos];
+    const temp = newRecitativos[index];
+    newRecitativos[index] = newRecitativos[index - 1];
+    newRecitativos[index - 1] = temp;
+    saveRecitativos(newRecitativos);
+  };
+
+  const moveRecitativoDown = (index: number) => {
+    if (index === recitativos.length - 1) return;
+    const newRecitativos = [...recitativos];
+    const temp = newRecitativos[index];
+    newRecitativos[index] = newRecitativos[index + 1];
+    newRecitativos[index + 1] = temp;
+    saveRecitativos(newRecitativos);
+  };
+
+  const deleteRecitativo = (index: number) => {
+    const newRecitativos = recitativos.filter((_, i) => i !== index);
+    saveRecitativos(newRecitativos);
+  };
+
+  return (
+    <RecitativosContext.Provider value={{ recitativos, addRecitativo, moveRecitativoUp, moveRecitativoDown, deleteRecitativo }}>
+      {children}
+    </RecitativosContext.Provider>
+  );
+};
+
+export const useRecitativos = () => {
+  const context = useContext(RecitativosContext);
+  if (!context) throw new Error('useRecitativos must be used within a RecitativosProvider');
+  return context;
+};

--- a/src/screens/DecorarScreen.tsx
+++ b/src/screens/DecorarScreen.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components/native";
 import NavBar from "@components/NavBar";
 import { useNavigation, useRoute, RouteProp, NavigationProp } from '@react-navigation/native';
 import { ArrowFatLeft } from "phosphor-react-native";
-import { TextInput } from "react-native";
+import { TextInput, InteractionManager } from "react-native";
 
 const DecorarScreen = () => {
   const navigation = useNavigation<NavigationProp<Record<string, object | undefined>>>();
@@ -14,7 +14,9 @@ const DecorarScreen = () => {
 
   useEffect(() => {
     // Focus the input and open the keyboard when the screen mounts
-    inputRef.current?.focus();
+    InteractionManager.runAfterInteractions(() => {
+      inputRef.current?.focus();
+    });
   }, []);
 
   const handleBack = () => navigation.navigate('Main');
@@ -30,7 +32,6 @@ const DecorarScreen = () => {
         <TextInput
           ref={inputRef}
           style={{ height: 0, width: 0, position: 'absolute', opacity: 0 }}
-          autoFocus
           autoCorrect={false}
           spellCheck={false}
           autoComplete="off"

--- a/src/screens/EscolhaVersosScreen.tsx
+++ b/src/screens/EscolhaVersosScreen.tsx
@@ -4,12 +4,14 @@ import Button from "@components/Button";
 import NavBar from "@components/NavBar";
 import { ArrowFatLeft, ArrowFatRight, Check, Checks } from "phosphor-react-native";
 import ARC from "@assets/ARC.json";
-import { FlatList } from "react-native";
+import { FlatList, Alert } from "react-native";
 import { useNavigation, useRoute, RouteProp, NavigationProp } from '@react-navigation/native';
+import { useRecitativos } from "@contexts/RecitativosContext";
 
 const EscolhaVersosScreen = () => {
   const navigation = useNavigation<NavigationProp<Record<string, object | undefined>>>();
   const route = useRoute<RouteProp<Record<string, { bookName?: string; chapterIndex?: number }>, string>>();
+  const { recitativos, addRecitativo } = useRecitativos();
   const { bookName, chapterIndex } = route.params || {};
 
   const book = ARC.find((book: { name: string }) => book.name === bookName);
@@ -49,7 +51,15 @@ const EscolhaVersosScreen = () => {
     const title = sorted.length === 1
       ? `${bookName} ${chapterIndex + 1}:${first}`
       : `${bookName} ${chapterIndex + 1}:${first}-${last}`;
+
+    const isDuplicate = recitativos.some(r => r.title === title);
+    if (isDuplicate) {
+      Alert.alert("Seleção Duplicada", "Esta seleção já está na sua lista de versos.");
+      return;
+    }
+
     const verses = sorted.map(idx => chapterVerses[idx]);
+    addRecitativo({ title, verses });
     navigation.navigate('Decorar', { title, verses });
   };
 

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,27 +1,61 @@
 import React from "react";
-import { FlatList, View } from "react-native";
-import { useTheme } from 'styled-components/native';
+import { FlatList, View, Text, Alert, AlertButton } from "react-native";
+import styled, { useTheme } from 'styled-components/native';
 import NavBar from "@components/NavBar";
 import ListItemComponent, { ListItemProps } from "@components/ListItem";
 import Button from "@components/Button";
 import { Gear, Plus } from "phosphor-react-native";
+import { useRecitativos } from "@contexts/RecitativosContext";
 
 export default function MainScreen({ navigation }: any) {
   const theme = useTheme();
+  const { recitativos, moveRecitativoUp, moveRecitativoDown, deleteRecitativo } = useRecitativos();
 
-  const list: ListItemProps[] = [
-    {
-      type: "Icon",
-      title: "Genesis 1:1",
-      description: "No princípio, Deus criou os céus e a terra.",
-      hasRightIcon: true,
-      avatar: { uri: "" }, // Provide a dummy avatar for type compatibility
-    },
-    // ... add more items as needed
-  ];
+  const handleLongPress = (index: number) => {
+    const menuOptions: AlertButton[] = [];
+
+    if (index > 0) {
+      menuOptions.push({
+        text: "Mover para cima",
+        onPress: () => moveRecitativoUp(index),
+      });
+    }
+
+    if (index < recitativos.length - 1) {
+      menuOptions.push({
+        text: "Mover para baixo",
+        onPress: () => moveRecitativoDown(index),
+      });
+    }
+
+    menuOptions.push(
+      {
+        text: "Excluir",
+        onPress: () => deleteRecitativo(index),
+        style: "destructive",
+      },
+      {
+        text: "Cancelar",
+        style: "cancel",
+      }
+    );
+
+    Alert.alert("Ações", "", menuOptions, { cancelable: true });
+  };
+
+  const list: ListItemProps[] = recitativos.map((item, index) => ({
+    type: "Icon",
+    title: item.title,
+    hasRightIcon: true,
+    onPress: () => navigation.navigate('Decorar', { title: item.title, verses: item.verses }),
+    onLongPress: () => handleLongPress(index),
+    avatar: { uri: "" }, // Provide a dummy avatar for type compatibility
+  }));
 
   const renderItem = ({ item }: { item: ListItemProps }) => (
-    <ListItemComponent {...item} />
+    <View style={{ marginBottom: 12 }}>
+      <ListItemComponent {...item} />
+    </View>
   );
 
   return (
@@ -33,6 +67,11 @@ export default function MainScreen({ navigation }: any) {
         renderItem={renderItem}
         keyExtractor={(_, index) => index.toString()}
         ListHeaderComponent={<NavBar title="Meus Recitativos" />}
+        ListEmptyComponent={
+          <EmptyListContainer>
+            <EmptyListText>não há versos salvos</EmptyListText>
+          </EmptyListContainer>
+        }
       />
       <View style={{ padding: 16 }}>
         <Button
@@ -51,3 +90,15 @@ export default function MainScreen({ navigation }: any) {
     </View>
   );
 }
+
+const EmptyListContainer = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+const EmptyListText = styled.Text`
+  ${({ theme }) => theme.HEADING.H2};
+  color: ${({ theme }) => theme.COLORS.NEUTRAL_DARK_LIGHTEST};
+  font-style: italic;
+`;


### PR DESCRIPTION
Introduces RecitativosContext for managing saved recitativos with persistent storage using AsyncStorage. Updates MainScreen and EscolhaVersosScreen to use the context for listing, adding, reordering, and deleting recitativos. Enhances ListItem components to support onPress and onLongPress handlers. Adds empty state UI for the main list and ensures input focus is handled more reliably in DecorarScreen. Also adds @react-native-async-storage/async-storage as a dependency.